### PR TITLE
Fix ETA formatting for 24h locales

### DIFF
--- a/app/src/main/java/org/cygnusx1/openbu/ui/DashboardScreen.kt
+++ b/app/src/main/java/org/cygnusx1/openbu/ui/DashboardScreen.kt
@@ -3,10 +3,10 @@ package org.cygnusx1.openbu.ui
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
+import android.text.format.DateFormat
 import android.util.Log
 import java.util.Calendar
 import java.text.SimpleDateFormat
-import java.util.Locale
 import org.cygnusx1.openbu.data.PrinterSeries
 import org.cygnusx1.openbu.data.printerSeriesFromSerial
 import androidx.compose.foundation.Image
@@ -125,6 +125,7 @@ import org.cygnusx1.openbu.data.HmsLookup
 import org.cygnusx1.openbu.data.HmsWikiResult
 import org.cygnusx1.openbu.network.PrinterStatus
 import org.cygnusx1.openbu.network.SavedPrinter
+import androidx.compose.ui.platform.LocalLocale
 
 private val HorizontalCardPadding = 4.dp
 private val VerticalCardPadding = 4.dp
@@ -886,7 +887,8 @@ private fun PrintStatusCard(
 
     val etaText = if (showEta && remainingMin > 0) {
         val cal = Calendar.getInstance().apply { add(Calendar.MINUTE, remainingMin) }
-        val fmt = SimpleDateFormat("h:mma", Locale.getDefault())
+        val pat = if (DateFormat.is24HourFormat(LocalContext.current)) "H:mm" else "h:mma"
+        val fmt = SimpleDateFormat(pat, LocalLocale.current.platformLocale)
         "(ETA ${fmt.format(cal.time).lowercase()})"
     } else ""
 


### PR DESCRIPTION
Hi, this is a quick fix to show ETA correctly on devices with 24h time enabled. It is responsive to changes in system settings (without app restart) and shouldn't change anything on 12h locale devices.

| before | after |
|-----------|---------|
| <img width="1220" height="2712" alt="Screenshot_20260802-124719_Openbu" src="https://github.com/user-attachments/assets/f42fca83-b926-42a2-b541-be89064d39e7" /> | <img width="1220" height="2712" alt="Screenshot_20260802-124715_Openbu (Debug)" src="https://github.com/user-attachments/assets/cb31d02b-56da-4398-abc5-0c76e6454b30" /> |